### PR TITLE
Add option to open link and comment with a single click

### DIFF
--- a/lib/defaults.json
+++ b/lib/defaults.json
@@ -1,11 +1,12 @@
 {
-    "settings_version": 9,
+    "settings_version": 10,
     "settings": {
         "visual_theme": true,
         "high_contrast": false,
         "gray_visited_links": false,
         "infinite_scrolling": true,
         "open_links_in_new_tabs": false,
+        "open_link_and_comment": false,
         "highlight_links_when_returning": true,
         "accurate_domain_names": true,
         "fold_comments": true,

--- a/lib/modules/open_link_and_comment.js
+++ b/lib/modules/open_link_and_comment.js
@@ -1,0 +1,38 @@
+HNSpecial.settings.registerModule("open_link_and_comment", function () {
+  function addLinkAndCommentLink() {
+    if (_.isCommentPage()) return;
+
+    var subtexts = _.toArray(document.getElementsByClassName("subtext"));
+
+    subtexts.forEach(function (subtext) {
+      if (!subtext.getAttribute("data-hnspecial-linkcomment")) {
+        var linkUrl = subtext.parentNode.previousSibling.lastChild.firstChild.href;
+        var commentUrl = subtext.lastChild.href;
+
+        var linkAndComment = document.createElement("a");
+        linkAndComment.setAttribute("href", "#");
+        linkAndComment.setAttribute("commentUrl", commentUrl);
+        linkAndComment.setAttribute("linkUrl", linkUrl);
+        linkAndComment.onclick = openMultipleLinks;
+        linkAndComment.textContent = "[l+c]";
+
+        var separator = document.createTextNode(" | ");
+        subtext.appendChild(separator);
+        subtext.appendChild(linkAndComment);
+        subtext.setAttribute("data-hnspecial-linkcomment", "true");
+      }
+    });
+  }
+
+  function openMultipleLinks(e) {
+    e.preventDefault();
+    window.open(this.getAttribute('commentUrl'));
+    window.open(this.getAttribute('linkUrl'));
+  }
+
+  // Run it
+  addLinkAndCommentLink();
+
+  // Subscribe to the event emitted when new links are present
+  HNSpecial.settings.subscribe("new links", addLinkAndCommentLink);
+});

--- a/lib/modules/open_link_and_comment.js
+++ b/lib/modules/open_link_and_comment.js
@@ -26,8 +26,13 @@ HNSpecial.settings.registerModule("open_link_and_comment", function () {
 
   function openMultipleLinks(e) {
     e.preventDefault();
-    window.open(this.getAttribute('commentUrl'));
-    window.open(this.getAttribute('linkUrl'));
+    // Only open the link once for a text submission
+    if(this.getAttribute('commentUrl') === this.getAttribute('linkUrl')) {
+      window.open(this.getAttribute('commentUrl'));
+    } else {
+      window.open(this.getAttribute('commentUrl'));
+      window.open(this.getAttribute('linkUrl'));
+    }
   }
 
   // Run it

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,7 @@
         "lib/modules/high_contrast.js",
         "lib/modules/gray_visited_links.js",
         "lib/modules/open_links_in_new_tabs.js",
+        "lib/modules/open_link_and_comment.js",
         "lib/modules/highlight_links_when_returning.js",
         "lib/modules/infinite_scrolling.js",
         "lib/modules/accurate_domain_names.js",


### PR DESCRIPTION
This feature adds the option to open the link and comment thread with a single click. It adds a [l+c] link after the comments link. See screenshot.

![](http://i.imgur.com/Wey3wr8.png)

This was inspired by the Reddit Enhancement Suite that has this feature. Always loved it and thought it would be nice for HN Special has well.

Comments?
