### PR TITLE
fix "more" link opening in new tab (fixes issue #61)

### DIFF
--- a/lib/tools/utility.js
+++ b/lib/tools/utility.js
@@ -83,7 +83,7 @@
   };
 
   _.isTitleLink = function (link) {
-    return link.parentElement.classList.contains("title") && !link.getAttribute("href").match(/^\/x\S+/) && !link.classList.contains("hnspecial-infinite-pause");
+    return link.parentElement.classList.contains("title") && !link.getAttribute("href").match(/^news\?p=\d+/) && !link.classList.contains("hnspecial-infinite-pause");
   };
 
   _.isCommentLink = function (link) {


### PR DESCRIPTION
as far as I can tell the original regex was just a placeholder. if that's the case then its usage in isCommentPage should be reviewed.
