### PR TITLE
Update fold_comments.js

### DIFF
--- a/lib/modules/fold_comments.js
+++ b/lib/modules/fold_comments.js
@@ -6,7 +6,7 @@ HNSpecial.settings.registerModule("fold_comments", function () {
       var row = comment.parentElement.parentElement.parentElement.parentElement.parentElement; // Least horrible way to get to the comment row
 
       // Skip this row if we're on a comment permalink page and it's the comment at the top
-      if (row.nextSibling && row.nextSibling.getElementsByClassName("yclinks").length) return;
+      if (row.nextElementSibling && row.nextElementSibling.getElementsByClassName("yclinks").length) return;
 
       var comhead = comment.getElementsByClassName("comhead")[0];
       comhead.appendChild(document.createTextNode(" | "));


### PR DESCRIPTION
line 9: switched `row.nextSibling` for `row.nextElementSibling`, fixes recent issue with comment folding