### PR TITLE
Bug fix for infinite scroll links not opening in new tab (Closes #77)

### DIFF
--- a/lib/modules/infinite_scrolling.js
+++ b/lib/modules/infinite_scrolling.js
@@ -97,8 +97,8 @@ HNSpecial.settings.registerModule("infinite_scrolling", function () {
         _.toArray(dummy.getElementsByTagName("a")).forEach(function (link) {
           if (_.isTitleLink(link)) {
             var row = link.parentElement.parentElement;
-            var sub = row.nextSibling;
-            var empty = sub.nextSibling;
+            var sub = row.nextElementSibling;
+            var empty = sub.nextElementSibling;
 
             container.insertBefore(row, last);
             container.insertBefore(sub, last);


### PR DESCRIPTION
This should fix the issue with links added via infinite scroll not opening in a new tab despite the option being turned on.

The problem was that `#text` nodes were being added to the  `additions` array when adding new links. The first callback for the `"new links"` event then tried to call `querySelectorAll` on each addition, which threw a `TypeError` when it hit a `#text` node, preventing subsequent callbacks from being executed.

There are many instances throughout the code that use `nextSibling`, `previousSibling`, `firstChild`, and `lastChild` which I suspect may be susceptible to similar bugs. However, I'd need to decide whether non-`Element` nodes are something to avoid or include in each case. That is a potential refactor to consider but for now this fixes an immediate bug.
