### PR TITLE
modules: infinite_scrolling: use nextElementSibling

### DIFF
--- a/lib/modules/infinite_scrolling.js
+++ b/lib/modules/infinite_scrolling.js
@@ -97,8 +97,8 @@ HNSpecial.settings.registerModule("infinite_scrolling", function () {
         _.toArray(dummy.getElementsByTagName("a")).forEach(function (link) {
           if (_.isTitleLink(link)) {
             var row = link.parentElement.parentElement;
-            var sub = row.nextSibling;
-            var empty = sub.nextSibling;
+            var sub = row.nextElementSibling;
+            var empty = sub.nextElementSibling;
 
             container.insertBefore(row, last);
             container.insertBefore(sub, last);


### PR DESCRIPTION
this fixes tr.spacer not being loaded onto added pages.

Signed-off-by: thewisenerd <thewisenerd@protonmail.com>