### PR TITLE
MORE shouldn't open a new tab on the newest page when clicked

### DIFF
--- a/lib/tools/utility.js
+++ b/lib/tools/utility.js
@@ -83,7 +83,7 @@
   };
 
   _.isTitleLink = function (link) {
-    return link.parentElement.classList.contains("title") && !link.getAttribute("href").match(/^news\?\S+/) && !link.classList.contains("hnspecial-infinite-pause");
+    return link.parentElement.classList.contains("title") && !link.getAttribute("href").match(/^(news|newest)\?\S+/) && !link.classList.contains("hnspecial-infinite-pause");
   };
 
   _.isCommentLink = function (link) {


### PR DESCRIPTION
Hi,

I added `newest` to the regex that checks if a link is a title.
This way the MORE button on the newest page acts the same way as the one on the popular page and doesn't open a new tab when the "Open links in new tab" is set to ON.
