### PR TITLE
Use and return AbortController in request function

### DIFF
--- a/lib/tools/utility.js
+++ b/lib/tools/utility.js
@@ -32,13 +32,17 @@
   };
 
   _.request = function (url, callback) {
-    var request = new Request(url);
+    var controller = new AbortController();
 
-    fetch(request).then(response =>
+    fetch(url, { signal: controller.signal }).then(response =>
       response.text().then(text => callback(text))
-    );
+    ).catch((e) => {
+      if (e.name !== "AbortError") {
+        throw e
+      }
+    });
 
-    return request;
+    return controller;
   };
 
   _.createElement = function (type, options) {


### PR DESCRIPTION
Fixes #121 

Tooltips were not hiding because `abort` is not a function available on `Request` which was causing an error during the hide function of the tooltip module, which calls abort.