### PR TITLE
Do not strip `indent` attribute

### DIFF
--- a/lib/modules/visual_theme.js
+++ b/lib/modules/visual_theme.js
@@ -309,7 +309,7 @@ HNSpecial.settings.registerModule("visual_theme", function () {
         // This is contrived because .length changes, messing up the loop
         for (var i = 0; i < attrs.length; i++) {
           var attr = attrs[i].name;
-          if (["colspan", "class", "id", "type", "name", "value"].indexOf(attr) !== -1) continue;
+          if (["colspan", "class", "id", "type", "name", "value", "indent"].indexOf(attr) !== -1) continue;
           names.push(attr);
         }
 


### PR DESCRIPTION
HN is now using an attribute `indent` to identify how deeply nested a comment is. Since it will repeatedly check the next element and compare indent levels to see if it should additionally hide that element, we cannot strip this without breaking folding.

When stripping out `indent`, only the targeted comment is hidden, none of the sub-elements.