### PR TITLE
Fix infinite scrolling after page structure change

### DIFF
--- a/lib/modules/infinite_scrolling.js
+++ b/lib/modules/infinite_scrolling.js
@@ -104,7 +104,7 @@ HNSpecial.settings.registerModule("infinite_scrolling", function () {
 
         _.toArray(dummy.getElementsByTagName("a")).forEach(function (link) {
           if (_.isTitleLink(link)) {
-            var row = link.parentElement.parentElement;
+            var row = link.parentElement.parentElement.parentElement;
             var sub = row.nextElementSibling;
             var empty = sub.nextElementSibling;
 

--- a/lib/tools/utility.js
+++ b/lib/tools/utility.js
@@ -85,7 +85,7 @@
 
   _.isTitleLink = function (link) {
     return (
-      link.parentElement.classList.contains("title") &&
+      link.parentElement.classList.contains("titleline") &&
       !link.getAttribute("href").match(/^(news|newest|newcomments|threads|show|ask|jobs)\?\S+/) &&
       !link.classList.contains("hnspecial-infinite-pause")
     );


### PR DESCRIPTION
Fixes #127. The HTML structure recently changed which broke infinite scrolling:

Before:
```html
<td class="title">
<a href="https://johnedchristensen.github.io/WebbCompare/" class="titlelink">Compare Webb's Images to Hubble</a>
...
</td>
```

Now:

```html
<td class="title">
<span class="titleline">
<a href="https://engineeringmedia.com/books">The Fundamentals of Control Theory</a>
...
</span>
</td>
```